### PR TITLE
Improve performance when building the share porfolio user list

### DIFF
--- a/javascript/exaport.js
+++ b/javascript/exaport.js
@@ -110,6 +110,8 @@ window.jQueryExaport = jQuery.noConflict(true);
 					$('#sharing-userlist :checkbox[name="'+this.name+'"]').attr('checked', this.checked);
 				});
 				*/
+
+                // stop slow loading
 				$('#sharing-userlist .shareusers:checkbox').click(function(){
 					// enable/disable notifyuser, according to shared users checkbox
 					var $notifyboxes = $(this).closest('tr').find('.notifyusers');
@@ -120,12 +122,27 @@ window.jQueryExaport = jQuery.noConflict(true);
 					}
 					
 					// check/uncheck all users
-					var $courseCheckboxes = $('#sharing-userlist .shareusers:checkbox[courseid='+$(this).attr('courseid')+']')
+					var $courseCheckboxes = $('#sharing-userlist .shareusers:checkbox[courseid='+$(this).attr('courseid')+']');
 					$('#sharing-userlist .shareusers-check-all[courseid='+$(this).attr('courseid')+']').prop('checked', $courseCheckboxes.not(':checked').length == 0);
-				}).each(function(){
-					// wrapped in each, because triggerHandler only works on first element
-					$(this).triggerHandler('click');
 				});
+                $('.course-group-content').each(function(){
+                    var flag = 0;
+                    $(this).find( 'table > tbody > tr > td > input.shareusers').each(function(){
+                        if (flag==1)
+                            return false;
+                        if ($(this).prop('checked')==false)
+                            flag = 1;
+
+                        var $notifyboxes = $(this).closest('tr').find('.notifyusers');
+                        $notifyboxes.attr('disabled', !this.checked);
+                        if (!this.checked) {
+                            $notifyboxes.prop('checked', false);
+                        }
+                    });
+                    if (flag == 0) {
+                        $(this).find('table > tbody > tr > td > input.shareusers-check-all').prop('checked', true);
+                    }
+                });
 
 				// open/close course group
 				$('.course-group-title').on('click', function(){


### PR DESCRIPTION
For a large number of users in many courses, the userlist loading is super slow and chrome prompts to kill pages. The 'each' block for 'shareusers' checkbox is the reason behind it. The 'each' block is removed. 
A new block is added which while loading the page at start  checks if all users are selected and then check the course's share all checkbox depending on this, and adjust the notify button too. This improves the performance if there is a large number of users.