### PR TITLE
Avoid deprecated message in ajax request

### DIFF
--- a/inc.php
+++ b/inc.php
@@ -23,7 +23,7 @@ if (
     || (basename($_SERVER['SCRIPT_NAME']) == 'item_thumb.php' && optional_param('item_id', '0', PARAM_INT) > 0) // item thumbnials
 ) {
     @$CFG->debug = 5;
-    @error_reporting(E_ALL & ~E_NOTICE & ~E_WARNING);
+    @error_reporting(E_ALL & ~E_NOTICE & ~E_WARNING & ~E_DEPRECATED);
     @ini_set('display_errors', '5');
 }
 require_once(__DIR__ . '/lib/lib.php');


### PR DESCRIPTION
Since PHP 8.2, dynamic properties are deprecated. 

In exacomp/lib/classes.php, line 689, the __set() method is using dynamic properties :
```php
$this->$name = $value;
```
So when settings my portfolio view, ajax request to /blocks/exaport/views_mod.php response with deprecated message :

```
Deprecated: Creation of dynamic property block_exacomp\topic::$sorting is deprecated in /var/www/html/moodle/blocks/exacomp/lib/classes.php on line 689
Deprecated: Creation of dynamic property block_exacomp\topic::$title is deprecated in /var/www/html/moodle/blocks/exacomp/lib/classes.php on line 689

```


Even if configuring error_reporting  in php ini configuration, the deprecated message appear in ajax response. It's because error_reporting is changed in inc.php file.

The merge request is for removing  E_DEPRECATED  from error_reporting change made in inc.php file, so that deprecated message disappear from ajax request.
